### PR TITLE
ARVU-31 fix: headers 컴포넌트의 CodingroomsModal 닫히는 문제 수정

### DIFF
--- a/thiscoding/app/(components)/common/Headers.tsx
+++ b/thiscoding/app/(components)/common/Headers.tsx
@@ -68,8 +68,8 @@ const Headers = () => {
 
         <button onClick={openModal} className="hover:text-[#0095E8]">
           코드방 생성
-          {isModalOpen && <CodingroomsModal />}
         </button>
+          {isModalOpen && <CodingroomsModal />}
 
         <Link href="/qna" className="hover:text-[#0095E8]">
           질문 & 답변


### PR DESCRIPTION
코드방 생성 모달의 여닫힘 여부 조건식이 button 태그 내에 존재하여,
이를 button 태그 외부에 작성.